### PR TITLE
[Client]fix/calendar montch check 분기 수정

### DIFF
--- a/src/screens/CalendarScreen/index.js
+++ b/src/screens/CalendarScreen/index.js
@@ -211,15 +211,14 @@ const CalendarMain = () => {
             console.log('selected day', day);
             setClickedDate(day['dateString']);
           }}
-          // Handler which gets executed on day long press. Default = undefined
-          // onDayLongPress={(day) => {
-          //   console.log('selected day', day);
-          // }} -> 상현님 무지한 저는 이 코드를 이해할 수 없어서 우선 비활성화했습니다 ㅠ
-          // Month format in calendar title. Formatting values: http://arshaw.com/xdate/#Formatting
-
           monthFormat={'yyyy MM'}
           onMonthChange={(month) => {
             console.log('month changed', month);
+            if (month['month'] < 10) {
+              //해당 분기 추가
+              let before = month['month'];
+              month['month'] = `0${before}`;
+            }
             setSelectedMonth(`${month['year']}-${month['month']}`);
             setClickedDate(todayDate);
           }}


### PR DESCRIPTION
```js
 if (month['month'] < 10) {
              //해당 분기 추가
              let before = month['month'];
              month['month'] = `0${before}`;
            }
```

1월처럼 10보다 작은 월의 경우 위의 코드 추가함으로써 컬러 분기 되도록 수정했습니다.