### PR TITLE
[Client]카메라 촬영 후 사진 저장 및 서버 전달/서버 응답받은 약 결과값과 함께 redirect 로직 정리

### DIFF
--- a/src/screens/CameraScreen/index.js
+++ b/src/screens/CameraScreen/index.js
@@ -141,7 +141,7 @@ export default class CameraScreen extends React.Component {
                   alignItems: 'center',
                 }}
               >
-                <TouchableOpacity onPress={this.savePhoto}>
+                <TouchableOpacity onPress={this.handleSubmit}>
                   <Icon name="check-bold" size={60} color={'white'} />
                 </TouchableOpacity>
               </View>
@@ -182,65 +182,16 @@ export default class CameraScreen extends React.Component {
       let img = await this.camera.takePictureAsync({ quality: 0.5 });
       if (img) {
         console.log('photo uri: ', img.uri);
-        //this.savePhoto(img.uri);
         this.setState({ photo: img.uri, image: img, show: false });
-        //this.handleSubmit();
       }
     }
-  };
-  savePhoto = async () => {
-    try {
-      console.log(FileSystem.cacheDirectory);
-      // const getImg = await FileSystem.getInfoAsync(this.state.photo);
-      // console.log(getImg);
-      this.props.navigation.navigate('CheckScreen', {
-        uri: this.state.photo,
-      });
-    } catch (error) {
-      console.log(error);
-    }
-  };
-  // savePhoto = async () => {
-  //   try {
-  //     const { status } = await Permissions.askAsync(Permissions.CAMERA_ROLL);
-  //     if (status === 'granted') {
-  //       const asset = await MediaLibrary.createAssetAsync(this.state.photo);
-  //       let album = await MediaLibrary.getAlbumAsync(ALBUM_NAME);
-  //       if (album === null) {
-  //         album = await MediaLibrary.createAlbumAsync(ALBUM_NAME, asset);
-  //       } else {
-  //         await MediaLibrary.addAssetsToAlbumAsync([asset], album.id);
-  //       }
-  //     } else {
-  //       this.setState({ hasPermission: false });
-  //     }
-  //   } catch (error) {
-  //     console.log(error);
-  //   }
-  // };
-  // upload = async () => {
-  //   this.setState({ photo: img.uri, image: img, show: false });
-  //   this.handleSubmit();
-  // };
-  pickImage = async () => {
-    const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ImagePicker.MediaTypeOptions.All,
-      allowsEditing: true,
-    });
-    console.log('pickImage: ', result); //pickImage:  {cancelled: false, uri: "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAASABIAAD…v7EhjkvIwl2TuZs5A9Pxro4rsS7oA3LHOW/pWUmZ2d9T/2Q==", width: 3024, height: 4032} 로 잘 찍힘
-    //uri가 data:image/jpeg;base64 형식이다. data형식의 jpeg인 image이며 base64로 인코딩되어 있다는 뜻이다.
-    //이 뒤에 붙을 이미지를 텍스트로 인코딩해야한다.
-    if (!result.cancelled) {
-      this.setState({ photo: result.uri });
-    }
-    this.handleSubmit();
   };
   //이제 서버 전송전에 formData를 만들어 이미지 및 다른 정보를 보낼 준비를 합니다.
   //여기서 Blob를 핸들링 해야합니다.
   //다시 formData를 만들어봅시다
   //https://kyounghwan01.github.io/blog/React/image-upload/#base64-%EB%B3%80%ED%99%98
   handleSubmit = () => {
-    // dataURL 값이 data:image/jpeg:base64,~~~~~~~ 이므로 ','를 기점으로 잘라서 ~~~~~인 부분만 다시 인코딩
+    // 웹에서 실행시
     const byteString = atob(this.state.photo.split(',')[1]);
     const ab = new ArrayBuffer(byteString.length);
     const ia = new Uint8Array(ab);
@@ -255,6 +206,16 @@ export default class CameraScreen extends React.Component {
     console.log('handleSubmit photo: ', file);
     form_data.append('image', blob);
     console.log('handleSubmit form_data: ', form_data.entries().next());
+
+    //모바일에서 실행시
+    // let fileName = this.state.photo.split('Camera')[1];
+    // //결국 여기 쓰일 파일 이름이 keras에서 전달받은 약 이름 혹은, 유저가 직접 설정한 이름이 되어야 합니다,
+    // let form_data = new FormData();
+    // form_data.append('image', {
+    //   name: fileName,
+    //   type: 'image/jpeg',
+    //   uri: this.state.photo,
+    // });
     let url = 'http://localhost:5000/medicines/image';
     axios
       .post(url, form_data, {
@@ -265,6 +226,25 @@ export default class CameraScreen extends React.Component {
       .then((res) => {
         console.log(res.data);
       })
+      .then((res) => {
+        this.props.navigation.navigate('CheckScreen', {
+          uri: this.state.photo,
+          //mediname: res.data.name
+        });
+      })
       .catch((err) => console.log(err));
   };
+
+  // savePhoto = async () => {
+  //   try {
+  //     console.log(FileSystem.cacheDirectory);
+  //     // const getImg = await FileSystem.getInfoAsync(this.state.photo);
+  //     // console.log(getImg);
+  //     this.props.navigation.navigate('CheckScreen', {
+  //       uri: this.state.photo,
+  //     });
+  //   } catch (error) {
+  //     console.log(error);
+  //   }
+  // };
 }


### PR DESCRIPTION
camera screen 에서 사진 촬영 후 로직 정리했습니다.
(관련해서 savephoto/ pickphoto는 현정님께서 라이브러리에 저장하는 경우를 고려해서 짜주신 코드이고,
라이브러리에 자동저장하지 않기로 이야기되어서 삭제했습니다.)

1. 사진 촬영 후, 자동으로 이미지 캐싱처리 & setstate로 이미지 관련 정보 저장(takephoto 함수 실행)
2. 재촬영 묻는 화면에서, 재촬영하지 않고 넘어가겠다고 클릭 시에 
  a. handlesubmit 함수 실행 되어, 서버에 이미지 정보 전달
  b. 서버로 부터 이미지 추론 결과값 받으면 약 이름과 photo.uri를 params 값으로 가지고 다음 화면으로 전환

위와 같은 로직으로 코드 수정했습니다. 서버에서 약 이름 전달 주시는 코드 고려하여 이후에 코드 약간 수정하겠습니다!