### PR TITLE
[Client]/#4/mainPageStyleUpdate

### DIFF
--- a/src/screens/AlarmScreen/index.js
+++ b/src/screens/AlarmScreen/index.js
@@ -19,6 +19,7 @@ import { onChange } from 'react-native-reanimated';
 import CameraScreen from '../CameraScreen';
 import CameraNoticeScreen from '../CameraNoticeScreen';
 import { createStackNavigator } from 'react-navigation-stack';
+import { getStatusBarHeight } from 'react-native-status-bar-height';
 
 import { NavigationEvents } from 'react-navigation';
 
@@ -260,7 +261,14 @@ export default class AlarmScreen extends React.Component {
 
   render() {
     return (
-      <View style={{ backgroundColor: 'white' }}>
+      <View
+        style={{
+          backgroundColor: 'white',
+          paddingTop: getStatusBarHeight(),
+          height: window.height * 0.92 - 1,
+          paddingLeft: 20,
+        }}
+      >
         <NavigationEvents
           onDidFocus={(payload) => {
             const resultArr = this.state.alarmMedicine;
@@ -275,43 +283,37 @@ export default class AlarmScreen extends React.Component {
             console.log('resultArr  =>', resultArr);
           }}
         />
-        <ScrollView
+        <Text
           style={{
             marginTop: 30,
-            backgroundColor: 'white',
-            paddingLeft: 20,
-            height: window.height * 0.92 - 30,
+            fontSize: 24,
+            fontWeight: '300',
+          }}
+        >
+          약 올리기
+        </Text>
+        <View
+          style={{
+            borderBottomStyle: 'solid',
+            borderBottomWidth: 5,
+            borderBottomColor: '#6a9c90',
+            alignSelf: 'flex-start',
+            marginBottom: window.height * 0.02,
           }}
         >
           <Text
             style={{
-              fontSize: 24,
-              fontWeight: '300',
+              alignSelf: 'center',
+              marginTop: 5,
+              fontSize: 20,
+              fontWeight: 'bold',
+              paddingBottom: 5,
             }}
           >
-            약 올리기
+            복용 알람 등록하기
           </Text>
-          <View
-            style={{
-              borderBottomStyle: 'solid',
-              borderBottomWidth: 5,
-              borderBottomColor: '#6a9c90',
-              alignSelf: 'flex-start',
-              marginBottom: window.height * 0.02,
-            }}
-          >
-            <Text
-              style={{
-                alignSelf: 'center',
-                marginTop: 5,
-                fontSize: 20,
-                fontWeight: 'bold',
-                paddingBottom: 5,
-              }}
-            >
-              복용 알람 등록하기
-            </Text>
-          </View>
+        </View>
+        <ScrollView>
           {/* -- 약 올리기 뷰 -- */}
           <View style={styles.viewBox}>
             <View style={styles.seclectView}>

--- a/src/screens/AlarmUpdateScreen/index.js
+++ b/src/screens/AlarmUpdateScreen/index.js
@@ -16,6 +16,9 @@ import Icon from 'react-native-vector-icons/FontAwesome5';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { NavigationEvents } from 'react-navigation';
 import AsyncStorage, { useAsyncStorage } from '@react-native-community/async-storage';
+
+import { getStatusBarHeight } from 'react-native-status-bar-height';
+
 const { getItem } = useAsyncStorage('@yag_olim');
 
 const window = Dimensions.get('window');
@@ -167,7 +170,14 @@ export default class AlarmUpdateScreen extends React.Component {
 
   render() {
     return (
-      <View style={{ backgroundColor: 'white' }}>
+      <View
+        style={{
+          height: window.height * 0.92 - 1,
+          backgroundColor: 'white',
+          paddingTop: getStatusBarHeight(),
+          paddingLeft: 20,
+        }}
+      >
         <NavigationEvents
           onDidFocus={(payload) => {
             const startDayValue = new Date(this.state.totalStartDate).getDay();
@@ -176,44 +186,38 @@ export default class AlarmUpdateScreen extends React.Component {
             this.setState({ endDay: this.state.weekName[endDayValue] });
           }}
         />
-        <ScrollView
+
+        <Text
           style={{
             marginTop: 30,
-            backgroundColor: 'white',
-            paddingLeft: 20,
-            height: window.height * 0.92 - 30,
+            fontSize: 24,
+            fontWeight: '300',
+          }}
+        >
+          알람 수정
+        </Text>
+        <View
+          style={{
+            borderBottomStyle: 'solid',
+            borderBottomWidth: 5,
+            borderBottomColor: '#6a9c90',
+            alignSelf: 'flex-start',
+            marginBottom: window.height * 0.02,
           }}
         >
           <Text
             style={{
-              fontSize: 24,
-              fontWeight: '300',
+              alignSelf: 'center',
+              marginTop: 5,
+              fontSize: 20,
+              fontWeight: 'bold',
+              paddingBottom: 5,
             }}
           >
-            알람 수정
+            복용 알람 수정하기
           </Text>
-          <View
-            style={{
-              borderBottomStyle: 'solid',
-              borderBottomWidth: 5,
-              borderBottomColor: '#6a9c90',
-              alignSelf: 'flex-start',
-              marginBottom: window.height * 0.02,
-            }}
-          >
-            <Text
-              style={{
-                alignSelf: 'center',
-                marginTop: 5,
-                fontSize: 20,
-                fontWeight: 'bold',
-                paddingBottom: 5,
-              }}
-            >
-              복용 알람 수정하기
-            </Text>
-          </View>
-
+        </View>
+        <ScrollView>
           {/* -- 상단 복용 여부 버튼 -- */}
           <View
             style={{

--- a/src/screens/CalendarScreen/index.js
+++ b/src/screens/CalendarScreen/index.js
@@ -6,6 +6,9 @@ import axios from 'axios';
 import moment from 'moment';
 import AntDesign from 'react-native-vector-icons/AntDesign';
 import { useAsyncStorage } from '@react-native-community/async-storage';
+
+import { getStatusBarHeight } from 'react-native-status-bar-height';
+
 const { getItem } = useAsyncStorage('@yag_olim');
 
 const window = Dimensions.get('window');
@@ -28,7 +31,26 @@ const CalendarMain = ({ navigation }) => {
 
   const [clickedDate, setClickedDate] = useState(todayDate);
   console.log('clickedDate:', clickedDate);
-  const [clickedList, setClickedList] = useState([]);
+  const [clickedList, setClickedList] = useState([
+    {
+      title: '비타민',
+      cycle: 1,
+      memo: '아침마다',
+      schedules_date_id: 10,
+      schedules_common_id: 2,
+      time: '22:00',
+      check: false,
+    },
+    {
+      title: '비타민',
+      cycle: 2,
+      memo: '자기 전에 꼭 먹어',
+      schedules_date_id: 33,
+      schedules_common_id: 5,
+      time: '23:30',
+      check: false,
+    },
+  ]);
   console.log('clickedList:', clickedList);
   //여기까지 제가 짠 코드입니다.
 
@@ -168,9 +190,9 @@ const CalendarMain = ({ navigation }) => {
   return (
     <View
       style={{
+        paddingTop: getStatusBarHeight(),
         backgroundColor: 'white',
         height: window.height * 0.92 - 1,
-
         flex: 1,
         flexDirection: 'column',
       }}

--- a/src/screens/HomeScreen/index.js
+++ b/src/screens/HomeScreen/index.js
@@ -3,7 +3,7 @@ import axios from 'axios';
 import moment from 'moment';
 import { View, Text, Dimensions, FlatList, StyleSheet, ScrollView } from 'react-native';
 import CountdownTimer from '../../components/CountdownTimer';
-// import AlarmList from '../../components/AlarmList';
+import { getStatusBarHeight } from 'react-native-status-bar-height';
 
 import Alarm from '../../components/Alarm';
 import { useAsyncStorage } from '@react-native-community/async-storage';
@@ -74,6 +74,8 @@ const HomeScreen = () => {
     <View
       style={{
         height: window.height,
+        backgroundColor: 'white',
+        paddingTop: getStatusBarHeight(),
       }}
     >
       <View

--- a/src/screens/MedicineBoxScreen/index.js
+++ b/src/screens/MedicineBoxScreen/index.js
@@ -8,6 +8,7 @@ import {
   StyleSheet,
   Image,
 } from 'react-native';
+import { getStatusBarHeight } from 'react-native-status-bar-height';
 
 const window = Dimensions.get('window');
 
@@ -66,7 +67,14 @@ const MedicineBox = () => {
 
   if (cameraTabSelected) {
     return (
-      <View style={{ backgroundColor: 'white', height: window.height * 0.92 - 1, paddingLeft: 20 }}>
+      <View
+        style={{
+          backgroundColor: 'white',
+          height: window.height * 0.92 - 1,
+          paddingLeft: 20,
+          paddingTop: getStatusBarHeight(),
+        }}
+      >
         <Text
           style={{
             marginTop: 30,

--- a/src/screens/SelfInputScreen/index.js
+++ b/src/screens/SelfInputScreen/index.js
@@ -45,7 +45,7 @@ export default class CheckScreen extends React.Component {
     return (
       <View
         style={{
-          height: window.height * 0.9,
+          height: window.height * 0.92 - 1,
           width: window.width - 40,
           marginLeft: 20,
           alignItems: 'center',

--- a/src/screens/index.js
+++ b/src/screens/index.js
@@ -24,10 +24,16 @@ const AlarmStack = createStackNavigator({
   SelfInputScreen: SelfInputScreen,
 });
 
-const CalendarStack = createStackNavigator({
-  Calendar: CalendarScreen,
-  AlarmUpdateScreen: AlarmUpdateScreen,
-});
+const CalendarStack = createStackNavigator(
+  {
+    Calendar: CalendarScreen,
+    AlarmUpdateScreen: AlarmUpdateScreen,
+  },
+  {
+    headerMode: 'none',
+    headerShown: false,
+  },
+);
 
 const TabNavigator = createBottomTabNavigator(
   {


### PR DESCRIPTION
1. 상단 탭 높이를 디바이스마다 알아서 감지해서 최상단 <View>의 marginTop 값으로 설정(아래 라이브러리 설치 필요)
>  $ npm install --save react-native-status-bar-height
2. 스크롤바를 사용하는 스크린의 경우 상단 타이틀 영역은 제외하고 스크롤 되도록 변경
