### PR TITLE
[Client]Fix/alarm redirect

### DIFF
--- a/src/screens/AlarmScreen/index.js
+++ b/src/screens/AlarmScreen/index.js
@@ -244,6 +244,23 @@ export default class AlarmScreen extends React.Component {
                           .then(() => {
                             console.log('medicines, user medicines API');
                             this.props.navigation.navigate({ routeName: 'Calendar' });
+                            this.setState({
+                              alarmTitle: '',
+                              alarmMemo: '',
+                              startYear: moment().format().substring(0, 4),
+                              startMonth: moment().format().substring(5, 7),
+                              startDate: moment().format().substring(8, 10),
+                              startDay: moment().format('dddd'),
+                              endYear: moment().format().substring(0, 4),
+                              endMonth: moment().format().substring(5, 7),
+                              endDate: moment().format().substring(8, 10),
+                              endDay: moment().format('dddd'),
+                              showTime: [],
+                              alarmInterval: 0,
+                              selectedHour: '',
+                              selectedMinute: '',
+                              alarmMedicine: [],
+                            });
                           })
                           .catch((err) => console.log(err));
                       })


### PR DESCRIPTION
1. alarm -> calendarScreen redirect 오류해결 완료 : tab 내에서의 스크린 이동
2. 알람 등록 후, 화면 이동 하면, 알람 등록 화면의 state들 다시 원래 상태로 원복하는 코드로 수정

*****이슈사항*******
@hdaleee 
상현님...ㅠㅠ 상현님께서 알람 등록 할때 겪으셨던 문제같은데, 결국 핵심에서 필요한거 같아요.
알람을 등록하고 나서 다시 calendar 화면이나 home 화면으로 와도 어플을 나갔다 들어오지 않는 이상, 방금 등록한/수정한 데이터가
반영되지 않아요.....

component did update cycle이 실행되거나, react에서 처럼 다시 뷰로 가면 re-rendering 이라는 개념이 있어야 할거 같은데,
RN은 그러지 않은가봐요...ㅠㅠ

해당 문제가 해결되지 않으면 알람 등록/수정이 반영되지 않을 것 같습니다.