### PR TITLE
[Client]/#98/Logout/구현완료

### DIFF
--- a/src/screens/MypageScreen/index.js
+++ b/src/screens/MypageScreen/index.js
@@ -2,10 +2,10 @@ import React from 'react';
 import axios from 'axios';
 import { View, Text, Dimensions, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
 import { getStatusBarHeight } from 'react-native-status-bar-height';
-import { NavigationEvents } from 'react-navigation';
+import { StackActions, NavigationActions, NavigationEvents } from 'react-navigation';
 
 import { useAsyncStorage } from '@react-native-community/async-storage';
-const { getItem } = useAsyncStorage('@yag_olim');
+const { getItem, removeItem } = useAsyncStorage('@yag_olim');
 
 const window = Dimensions.get('window');
 
@@ -44,6 +44,24 @@ export default class Mypage extends React.Component {
         console.error(err);
       });
   }
+
+  resetAction = StackActions.reset({
+    index: 0,
+    actions: [
+      NavigationActions.navigate({
+        routeName: 'LoginScreen',
+      }),
+    ],
+  });
+
+  logout = async () => {
+    try {
+      await removeItem();
+      this.props.navigation.dispatch(this.resetAction);
+    } catch (e) {
+      console.log(e);
+    }
+  };
 
   render() {
     return (
@@ -170,11 +188,7 @@ export default class Mypage extends React.Component {
 
           {/* -- 로그아웃 버튼 -- */}
           <View style={{ alignItems: 'center', marginBottom: 20, marginLeft: -20 }}>
-            <TouchableOpacity
-              onPress={() => {
-                constole.log('로그아웃 마치 내 월급');
-              }}
-            >
+            <TouchableOpacity onPress={this.logout}>
               <View
                 style={{
                   justifyContent: 'center',

--- a/src/screens/index.js
+++ b/src/screens/index.js
@@ -28,6 +28,7 @@ const window = Dimensions.get('window');
 const MypageStack = createStackNavigator(
   {
     Mypage: MypageScreen,
+    LoginScreen: LoginScreen,
     EditMyinfoScreen: EditMyinfoScreen,
   },
   {


### PR DESCRIPTION
1. 서버 Post Logout API가
```
 session.clear()    
 return redirect('/')
 ```
로 구현되어있습니다.

session이 아닌 token으로 권한을 검사해주고 있기 때문에 서버통신을 하지 않고
removeItem으로 토큰제거 후, 지금까지 쌓여있던 스택들을 모두 reset하도록 구현하였습니다. 
(reset을 하지 않으면 로그아웃되어있는데도 불구하고 뒤로가기 등을 누르면 자신이 들어갔던 페이지가 보입니다. )

핵심 코드는 
```

  resetAction = StackActions.reset({
    index: 0,
    actions: [
      NavigationActions.navigate({
        routeName: 'LoginScreen',
      }),
    ],
  });

  logout = async () => {
    try {
      await removeItem();
      this.props.navigation.dispatch(this.resetAction);
    } catch (e) {
      console.log(e);
    }
  };
 ```
입니다. 
