### PR TITLE
[Client]/Fix/#10/Delete Whole/Clicked schedules API연동

### DIFF
--- a/src/screens/AlarmUpdateScreen/DeleteCheck.js
+++ b/src/screens/AlarmUpdateScreen/DeleteCheck.js
@@ -5,6 +5,9 @@ import axios from 'axios';
 import { getStatusBarHeight } from 'react-native-status-bar-height';
 import { NavigationEvents } from 'react-navigation';
 
+import AsyncStorage, { useAsyncStorage } from '@react-native-community/async-storage';
+const { getItem } = useAsyncStorage('@yag_olim');
+
 const window = Dimensions.get('window');
 
 export default class CheckScreen extends React.Component {
@@ -14,70 +17,71 @@ export default class CheckScreen extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = {};
+    this.state = {
+      schedules_common_id: this.props.navigation.getParam('schedules_common_id'),
+      clickedDate: this.props.navigation.getParam('clickedDate'),
+    };
   }
 
   deleteWholeSchedules = () => {
-    console.log('전체 삭제하기 눌려따!');
     async function get_token() {
       const token = await getItem();
       return token;
     }
-    get_token().then((token) => {
-      axios
-        .delete(
-          'http://127.0.0.1:5000/schedules-commons/schedules-dates',
-          {
-            schedules_common: {
-              schedules_common_id: this.state.schedules_common_id,
-            },
+    get_token()
+      .then((token) => {
+        axios({
+          method: 'delete',
+          url: 'http://127.0.0.1:5000/schedules-commons/schedules-dates',
+          headers: {
+            Authorization: token,
           },
-          {
-            headers: {
-              Authorization: token,
-            },
+          params: {
+            schedules_common_id: this.state.schedules_common_id,
           },
-        )
-        .then((res) => {
-          console.log('전체 알람 일정 삭제 완료: ', res.data.message);
-          this.props.navigation.navigate('Calendar'); //삭제 후 calendarpage로 리다이렉트
         })
-        .catch((err) => {
-          console.error(err);
-        });
-    });
+          .then((res) => {
+            console.log('전체 알람 일정 삭제 완료: ', res.data.message);
+            this.props.navigation.navigate('Calendar'); //삭제 후 calendarpage로 리다이렉트
+          })
+          .catch((err) => {
+            console.error(err);
+          });
+      })
+      .catch((err) => {
+        console.error(err);
+      });
   };
 
   deleteClickedSchedules = () => {
-    console.log('해당 날짜 알람 삭제하기 눌려따!');
     async function get_token() {
       const token = await getItem();
       return token;
     }
-    get_token().then((token) => {
-      axios
-        .delete(
-          'http://127.0.0.1:5000/schedules-commons/schedules-dates',
-          {
-            schedules_common: {
-              schedules_common_id: this.state.schedules_common_id,
-              date: this.state.clickedDate,
-            },
+    get_token()
+      .then((token) => {
+        axios({
+          method: 'delete',
+          url: 'https://hj-medisharp.herokuapp.com/schedules-commons/schedules-dates',
+          headers: {
+            Authorization: token,
           },
-          {
-            headers: {
-              Authorization: token,
-            },
+          params: {
+            schedules_common_id: this.state.schedules_common_id,
+            date: this.state.clickedDate,
           },
-        )
-        .then((res) => {
-          console.log('해당 날짜 알람 삭제 완료: ', res.data.message);
-          this.props.navigation.navigate('Calendar'); //삭제 후 calendarpage로 리다이렉트
         })
-        .catch((err) => {
-          console.error(err);
-        });
-    });
+          .then((res) => {
+            console.log('해당 날짜 알람 삭제 완료: ', res.data.message);
+            this.props.navigation.navigate('Calendar'); //삭제 후 calendarpage로 리다이렉트
+          })
+          .catch((err) => {
+            console.error(err);
+          });
+      })
+      .catch((err) => {
+        console.error(err);
+      });
   };
 
   render() {
@@ -141,9 +145,7 @@ export default class CheckScreen extends React.Component {
             }}
           >
             <TouchableOpacity
-              onPress={() => {
-                this.deleteClickedSchedules;
-              }}
+              onPress={this.deleteClickedSchedules}
               style={{
                 marginTop: 10,
                 width: window.width * 0.42,
@@ -162,9 +164,7 @@ export default class CheckScreen extends React.Component {
             </TouchableOpacity>
 
             <TouchableOpacity
-              onPress={() => {
-                this.deleteWholeSchedules;
-              }}
+              onPress={this.deleteWholeSchedules}
               style={{
                 marginTop: 10,
                 width: window.width * 0.42,

--- a/src/screens/AlarmUpdateScreen/index.js
+++ b/src/screens/AlarmUpdateScreen/index.js
@@ -756,7 +756,10 @@ export default class AlarmUpdateScreen extends React.Component {
             {/* -- 삭제하기 분기페이지로 슝! -- */}
             <TouchableOpacity
               onPress={() => {
-                navigation.navigate('DeleteCheck');
+                this.props.navigation.navigate('DeleteCheck', {
+                  schedules_common_id: this.state.schedules_common_id,
+                  clickedDate: this.state.clickedDate,
+                });
               }}
             >
               <View


### PR DESCRIPTION
원래 알람수정페이지에서 삭제버튼2개(전체삭제/해당알람만삭제)를 만들고 거기에 API연동을 해놓았는데 =>
삭제버튼선택 페이지가 추가되면서 버튼만 이동하고 API연동 코드는 이동을 하지 않아서 삭제버튼이 실행되지 않았던 문제 해결하였습니다. 

**done1** -  삭제선택페이지로 넘어갈때 clickedDate, schedules_common_id 를 params로 넘겨주어야해서 수정하였습니다. 
```
 this.props.navigation.navigate('DeleteCheck', {
                  schedules_common_id: this.state.schedules_common_id,
                  clickedDate: this.state.clickedDate,
                });
 ```

**done2** -  이를 API에서 body가 아닌 params로 담아서 요청합니다. 
**done3** - 삭제 후 Calendar 페이지로 잘 navigate되어서 삭제된 데이터로 랜더링 잘 됩니다. 


