### PR TITLE
Refactoring/home screen api 하나로 통합

### DIFF
--- a/src/screens/HomeScreen/index.js
+++ b/src/screens/HomeScreen/index.js
@@ -33,7 +33,6 @@ Notifications.setNotificationHandler({
 const HomeScreen = ({ navigation }) => {
   const [GetTodayChecked, setGetTodayChecked] = useState([]);
   const [alarmList, setTodayAlarm] = useState([]);
-  const [expoPushToken, setExpoPushToken] = useState('');
   const useEffectForToday = () => {
     async function get_token() {
       const token = await getItem();
@@ -42,17 +41,19 @@ const HomeScreen = ({ navigation }) => {
     get_token().then((token) => {
       axios({
         method: 'get',
-        url: 'http://127.0.0.1:5000/schedules-dates/check/today',
+        url: 'http://127.0.0.1:5000/schedules-dates/today',
         headers: {
           Authorization: token,
         },
         params: {
-          start_day: moment().subtract(8, 'd').format('YYYY-MM-DD'),
-          end_day: moment().subtract(1, 'd').format('YYYY-MM-DD'),
+          startDay: moment().subtract(8, 'd').format('YYYY-MM-DD'),
+          endDay: moment().subtract(1, 'd').format('YYYY-MM-DD'),
+          date: moment().format('YYYY-MM-DD'), //2020-11-22
         },
       })
         .then((data) => {
-          setGetTodayChecked(data.data.results);
+          setGetTodayChecked(data.data.results.todayCheck);
+          setTodayAlarm(data.data.results.todayAlarm);
         })
         .catch((err) => {
           console.error(err);
@@ -68,35 +69,6 @@ const HomeScreen = ({ navigation }) => {
             { cancelable: false },
           );
         });
-      get_token().then((token) => {
-        axios({
-          method: 'get',
-          url: `http://127.0.0.1:5000/schedules-dates/schedules-commons/alarm`,
-          headers: {
-            Authorization: token,
-          },
-          params: {
-            date: moment().format('YYYY-MM-DD'), //2020-11-22
-          },
-        })
-          .then((data) => {
-            setTodayAlarm(data.data.results); //변경 후 상태를 axios 응답결과로 변경해줍니다.
-          })
-          .catch((err) => {
-            console.error(err);
-            Alert.alert(
-              '에러가 발생했습니다!',
-              '다시 시도해주세요',
-              [
-                {
-                  text: '다시시도하기',
-                  onPress: () => useEffectForToday(),
-                },
-              ],
-              { cancelable: false },
-            );
-          });
-      });
     });
   };
   useEffect(() => {


### PR DESCRIPTION
**추가적으로 비슷한 이슈에 대해서 branch를 쪼개서 작업할때,
초기 작업 branch에서 하부 branch를 만들고, pr 할때 Dev가 아니라 가장 최상단의 branch로 진행하면 코드가 중복되는 것없이 
전체적으로 잘 합쳐지더라구요. 따라서 저는 api_refactor_home으로 작업을 시작하였으니, 여기로 계속 pr 하고 
후에 하나씩 다 merge 하겠습니다!**

API를 하나로 통합하여 client로 오는 데이터 형태는 아래와 같습니다.
```
{
    "status": "OK",
    "message": "Successfully get today checked.",
    "results": {
        "todayCheck": [
            {
                "check": false
            },
            {
                "check": false
            },
            {
                "check": false
            },
            {
                "check": false
            }
        ],
        "todayAlarm": [
            {
                "schedules_common_id": 2,
                "title": "테스트",
                "cycle": 1,
                "memo": "테스트",
                "time": "17:15",
                "check": false,
                "push": "d1cbf93e-8aa7-4842-aa7a-65ef452986e3"
            },
            {
                "schedules_common_id": 1,
                "title": "테스트",
                "cycle": 1,
                "memo": "테스트",
                "time": "18:00",
                "check": false,
                "push": "993e17d8-f8a4-4aed-8ea4-3467e4696506"
            }
        ]
    }
}
```

또한, front에서는 자바스크립트 언어이므로 서버에 전달주는 파라미터의 형태를 camel형태로 바꾸었습니다.
이를 서버에서 데이터를 받은 다음 snake 형태로 바꾸어서 사용하도록 해주었습니다